### PR TITLE
Fixes #11: default/fallback template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added default template functionality
+
 ## 3.4.1 (May 18, 2019)
 
 - Fixed missing language string

--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ The plugin listens on the `\core\event\course_created` event and fires immediate
 
 You should consider overriding Moodle's default block settings in config.php: `$CFG->defaultblocks_override = '';`. Otherwise you will get two sets of blocks on course creation. Manually configure the blocks in the template course instead.
 
+### Default template
+
+You may specify a default template course in the "Default template course shortname" setting. If there is a course with that shortname, it will be used as the template for any course which matches the termcode regex but does _not_ match with a specific template.
+
+Let's say you  have termcode regex `/[A-Za-z0-9\.\-]+-([A-Z])-\d+/`, where the extracted substring is a department code. Then let's say you have the following template courses (shortnames):
+
+- Template-BIO
+- Template-HIS
+- Template-MTH
+
+These template courses will be used for Biology (BIO), History (HIS), and Math (MTH) courses respectively. Let's say you don't have specific templates for the other departments (POL, SCI, ENG, EPI, etc.), but you do want them to be based on a generalized template. You can create a fourth template course, and give it a shortname that matches the "Default template course shortname" setting value (eg `default-template`). Then, any course which matches the regex -- that is, any course from which a termcode is successfully extracted -- will be based on the default template course if it does not match a specific template.
+
+So, the course with idnumber `intro-BIO-201910` will still use `Template-BIO`, but the course with idnumber `shakespeare-sem-ENG-201920` will use `default-template`. A course with idnumber `study-abroad-201950` will not use any template.
+
 ### Sample regular expressions
 
 The basic use case above, `/[0-9]+\.([0-9]+)/`, would return `YYYYYY` from the following idnumbers:

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -90,9 +90,14 @@ class local_course_template_helper {
                 $templatecourse = $DB->get_record('course', array('shortname' => $templateshortname));
                 if (empty($templatecourse)) {
                     // No template found.
+                    $defaulttemplateshortname = get_config('local_course_template', 'defaulttemplate');
+                    $defaulttemplatecourse = $DB->get_record('course', array('shortname' => $defaulttemplateshortname));
+                    if (!empty($defaulttemplateshortname && !empty($defaulttemplatecourse)) {
+                        $cache->set($defaulttemplateshortname, $defaulttemplatecourse->id);
+                        return $defaulttemplatecourse->id;
+                    }
                     return false;
                 } else {
-                    $cache->set($templateshortname, $templatecourse->id);
                     return $templatecourse->id;
                 }
             } else {

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -92,7 +92,7 @@ class local_course_template_helper {
                     // No template found.
                     $defaulttemplateshortname = get_config('local_course_template', 'defaulttemplate');
                     $defaulttemplatecourse = $DB->get_record('course', array('shortname' => $defaulttemplateshortname));
-                    if (!empty($defaulttemplateshortname && !empty($defaulttemplatecourse)) {
+                    if (!empty($defaulttemplateshortname && !empty($defaulttemplatecourse))) {
                         $cache->set($defaulttemplateshortname, $defaulttemplatecourse->id);
                         return $defaulttemplatecourse->id;
                     }

--- a/lang/en/local_course_template.php
+++ b/lang/en/local_course_template.php
@@ -27,6 +27,8 @@ defined('MOODLE_INTERNAL') || die();
 $string['cachedef_backups'] = 'Course template backups';
 $string['cachedef_templates'] = 'Course template course ids';
 $string['cleanuptask'] = 'Cleanup course template backups';
+$string['defaulttemplate'] = 'Default template course shortname';
+$string['defaulttemplate_desc'] = 'Shortname of the default course template. Courses which do not match a template will use this one, if it exists.';
 $string['extracttermcode'] = 'Term code';
 $string['extracttermcode_desc'] = 'Used to populate [TERMCODE]. Derived from course idnumber.';
 $string['pluginname'] = 'Use template on course creation';

--- a/settings.php
+++ b/settings.php
@@ -35,4 +35,8 @@ if ($hassiteconfig) {
     $settings->add(new admin_setting_configtext('local_course_template/templatenameformat',
         new lang_string('templatenameformat', 'local_course_template'),
         new lang_string('templatenameformat_desc', 'local_course_template'), 'Template-[TERMCODE]', PARAM_NOTAGS));
+
+    $settings->add(new admin_setting_configtext('local_course_template/defaulttemplate',
+        get_string('defaulttemplate', 'local_course_template'),
+        get_string('defaulttemplate_desc', 'local_course_template'), '', PARAM_NOTAGS));
 }

--- a/tests/template_courses_test.php
+++ b/tests/template_courses_test.php
@@ -68,15 +68,6 @@ class local_course_template_template_courses_testcase extends advanced_testcase 
         $this->getDataGenerator()->create_module('forum',
             array('course' => $tc2->id, 'type' => 'news'));
 
-        $tcd = $this->getDataGenerator()->create_course(
-            array(
-                'name' => 'Default Template Course',
-                'shortname' => 'default-template'
-            )
-        );
-        $activity = $this->getDataGenerator()->create_module('url',
-            array('course' => $tcd->id));
-
         // Course matching 201610 template.
         $this->getDataGenerator()->create_course(
             array(
@@ -102,10 +93,32 @@ class local_course_template_template_courses_testcase extends advanced_testcase 
         $this->assertEquals(2, $DB->count_records('course_modules', array('course' => $c2->id)));
 
         // Course matching termcode regex, but not matching a template.
-        $this->assertEquals(1, $DB->count_records('url'));
+        // There's no default right now, so this should NOT be based on a template.
+        $this->assertEquals(0, $DB->count_records('url'));
         $this->getDataGenerator()->create_course(
             array(
                 'idnumber' => 'XLSB7201630'
+            )
+        );
+        $this->assertEquals(0, $DB->count_records('url'));
+        $this->assertEquals(2, $DB->count_records('assign'));
+
+        // Create default template course.
+        $tcd = $this->getDataGenerator()->create_course(
+            array(
+                'name' => 'Default Template Course',
+                'shortname' => 'default-template'
+            )
+        );
+        $activity = $this->getDataGenerator()->create_module('url',
+            array('course' => $tcd->id));
+
+        // Course matching termcode regex, but not matching a template.
+        // Now there IS a default template, so this should use it.
+        $this->assertEquals(1, $DB->count_records('url'));
+        $this->getDataGenerator()->create_course(
+            array(
+                'idnumber' => 'XLSB7201640'
             )
         );
         $this->assertEquals(2, $DB->count_records('url'));

--- a/tests/template_courses_test.php
+++ b/tests/template_courses_test.php
@@ -43,8 +43,9 @@ class local_course_template_template_courses_testcase extends advanced_testcase 
         // Configure the plugin.
         set_config('extracttermcode', '/[A-Za-z0-9\.]+([0-9]{6})/', 'local_course_template');
         set_config('templatenameformat', 'Template-[TERMCODE]', 'local_course_template');
+        set_config('defaulttemplate', 'default-template', 'local_course_template');
 
-        // Create the template course.
+        // Create the template courses.
         $tc1 = $this->getDataGenerator()->create_course(
             array(
                 'name' => 'Template Course 1',
@@ -66,6 +67,15 @@ class local_course_template_template_courses_testcase extends advanced_testcase 
             array('course' => $tc2->id, 'type' => 'news'));
         $this->getDataGenerator()->create_module('forum',
             array('course' => $tc2->id, 'type' => 'news'));
+
+        $tcd = $this->getDataGenerator()->create_course(
+            array(
+                'name' => 'Default Template Course',
+                'shortname' => 'default-template'
+            )
+        );
+        $activity = $this->getDataGenerator()->create_module('url',
+            array('course' => $tcd->id));
 
         // Course matching 201610 template.
         $this->getDataGenerator()->create_course(
@@ -91,9 +101,20 @@ class local_course_template_template_courses_testcase extends advanced_testcase 
         $this->assertEquals(1, $DB->count_records('forum', array('course' => $c2->id)));
         $this->assertEquals(2, $DB->count_records('course_modules', array('course' => $c2->id)));
 
+        // Course matching termcode regex, but not matching a template.
+        $this->assertEquals(1, $DB->count_records('url'));
+        $this->getDataGenerator()->create_course(
+            array(
+                'idnumber' => 'XLSB7201630'
+            )
+        );
+        $this->assertEquals(2, $DB->count_records('url'));
+        $this->assertEquals(2, $DB->count_records('assign'));
+
         // Course with no template.
         $this->getDataGenerator()->create_course();
 
+        $this->assertEquals(2, $DB->count_records('url'));
         $this->assertEquals(2, $DB->count_records('label'));
         $this->assertEquals(2, $DB->count_records('assign'));
 
@@ -118,6 +139,5 @@ class local_course_template_template_courses_testcase extends advanced_testcase 
         );
         $this->assertEquals(193, $DB->count_records('label'));
         $this->assertEquals(2, $DB->count_records('assign'));
-
     }
 }


### PR DESCRIPTION
Note that currently this affects courses which match the term code regex, but whose term code does not match a template. It does NOT work for courses which do not match the regex at all. I think this is correct, since it's probable that administrators don't want ALL courses copying the default template.