### PR TITLE
Fix errors in cleanup task

### DIFF
--- a/classes/cache.php
+++ b/classes/cache.php
@@ -38,6 +38,8 @@ class cache {
      * Unset the caches.
      */
     public static function clear() {
+        global $DB;
+
         $backupcache = \cache::make('local_course_template', 'backups');
         $backupcache->purge();
         $templatecache = \cache::make('local_course_template', 'templates');
@@ -56,6 +58,7 @@ class cache {
             );
             if ($file) {
                 $file->delete();
+                $cache = \cache::make('local_course_template', 'backups');
                 $cache->delete($record->contextid);
             }
         }

--- a/classes/task/cleanup_task.php
+++ b/classes/task/cleanup_task.php
@@ -50,6 +50,6 @@ class cleanup_task extends \core\task\scheduled_task {
         global $DB;
 
         // Find and prune template backups.
-        cache::clear();
+        \local_course_template\cache::clear();
     }
 }


### PR DESCRIPTION
There are several places where errors are happening in the cleanup task run. I'm guessing that in issue #22, the user is seeing that job fail and then rerun again and again.