### PR TITLE
01 add default termcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.7.1 (February 03, 2022)
+
+- Add default [Termcode] setting if empty
+
 ## Unreleased
 
 - Drop support for Moodle 3.7-3.8

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -93,6 +93,9 @@ class helper {
         $target = $DB->get_record('course', array('id' => $targetid), '*', MUST_EXIST);
         $subject = $target->idnumber;
         preg_match($pattern, $subject, $matches);
+
+        if (empty($matches)) $matches = array("",get_config('local_course_template', 'defaulttermcode')); 
+
         if (!empty($matches) && count($matches) >= 2) {
             $shortname = str_replace('[TERMCODE]', $matches[1],
                 get_config('local_course_template', 'templatenameformat'));

--- a/lang/en/local_course_template.php
+++ b/lang/en/local_course_template.php
@@ -39,3 +39,6 @@ $string['pluginname'] = 'Use template on course creation';
 $string['privacy:metadata'] = 'The Use template on course creation plugin does not store any personal data.';
 $string['templatenameformat'] = 'Template shortname format';
 $string['templatenameformat_desc'] = 'Expected shortname format for template courses';
+$string['defaulttermcode'] = 'Default [TERMCODE]';
+$string['defaulttermcode_desc'] = 'Replacement [TERMCODE] if empty ( must be >= 2 caracters)';
+

--- a/lang/fr/local_course_template.php
+++ b/lang/fr/local_course_template.php
@@ -1,0 +1,44 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Language strings for the plugin.
+ *
+ * @package    local_course_template
+ * @copyright  2016 Lafayette College ITS
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$string['cachedef_backups'] = 'Sauvegarde du modèle de cours (template)';
+$string['cachedef_templates'] = 'Ids du modèle de cours';
+$string['cleanuptask'] = 'Nettoyage de la sauvegarde du modèle de cours';
+$string['defaulttemplate'] = 'Nom abrégé du cours modèle par défaut';
+$string['defaulttemplate_desc'] = "Nom abrégé du cours modèle par defaut. Les cours qui ne correspondent pas à un modèle de cours utiliseront celci-ci, s'il existe.";
+$string['enablecaching'] = 'Activer le cache';
+$string['enablecaching_desc'] = "Quand le cache est actvé, le plugin créera une sauvegarde du cours modèle et utilisera cette sauvegarde pour les nouveaux cours jusqu'à ce que le cache soit vidé ou que la sauvegarde soit supprimée.";
+$string['event:template_copied:description'] = "Le cours modèle avec l'id {$a->templateid} a été copié dans le cours avec l'id {$a->courseid}";
+$string['event:template_copied:name'] = 'Cours modèle copié';
+$string['extracttermcode'] = 'Term code';
+$string['extracttermcode_desc'] = "Utilisé pour générer [TERMCODE]. Derivé du N° d'identification du cours.";
+$string['pluginname'] = "Utilisation d'un modèle à la créaction d'un cours";
+$string['privacy:metadata'] = "L'utilisation du plugin Utilisation d'un modèle à la créaction d'un cours ne stocke aucune donnée personnelle.";
+$string['templatenameformat'] = 'Préfix des noms abrégés des modèles de cours.';
+$string['templatenameformat_desc'] = 'Préfix attendu des noms abrégés des modèles de cours';
+$string['defaulttermcode'] = ' [TERMCODE] par défaut';
+$string['defaulttermcode_desc'] = '[TERMCODE] par defaut si la valeur est vide ( doit être >= 2 caractères)';
+

--- a/settings.php
+++ b/settings.php
@@ -38,6 +38,10 @@ if ($hassiteconfig) {
         new lang_string('templatenameformat', 'local_course_template'),
         new lang_string('templatenameformat_desc', 'local_course_template'), 'Template-[TERMCODE]', PARAM_NOTAGS));
 
+    $settings->add(new admin_setting_configtext('local_course_template/defaulttermcode',
+        new lang_string('defaulttermcode', 'local_course_template'),
+        new lang_string('defaulttermcode_desc', 'local_course_template'), '', PARAM_NOTAGS));
+
     $settings->add(new admin_setting_configtext('local_course_template/defaulttemplate',
         get_string('defaulttemplate', 'local_course_template'),
         get_string('defaulttemplate_desc', 'local_course_template'), '', PARAM_NOTAGS));

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2021032200;
+$plugin->version   = 2022020300;
 $plugin->requires  = 2020061500;
 $plugin->component = 'local_course_template';
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = 'v3.7.0';
+$plugin->release   = 'v3.7.1';


### PR DESCRIPTION
Hi, thanks for sharing your plugin
When using the local course template plugin with course [request](https://docs.moodle.org/33/en/Adding_a_new_course#Course_requests)  the template was not used as espected. In fact a blank course is created (with no Course ID number) and modified in second step. The solution proposed is to add an optional Termcode that is used if the Course ID number is empty.  The Helper is modify to check the Course ID number; if its empty then the $matches is set to default Termcode value.

A first version of french translation is also added .
 